### PR TITLE
Update emacs init.el. 

### DIFF
--- a/init.el
+++ b/init.el
@@ -1641,3 +1641,6 @@ The build string will be of the format:
                                  nil nil nil nil (tabulated-list-get-id))))
   (process-graceful-shutdown-send-signal-running-process proc SIGTERM)
   (run-at-time 30 nil #'process-graceful-shutdown-send-signal-running-process proc SIGKILL))
+
+
+(bind-key "s-t" #'org-agenda-list)

--- a/init.el
+++ b/init.el
@@ -330,7 +330,7 @@
   :hook (go-mode . yas-minor-mode)
   :init
   (custom-set-variables
-   '(yas-snippet-dirs '("/ng/symdon/snippets"))))
+   '(yas-snippet-dirs '("/opt/ng/symdon/snippets"))))
 (use-package smex :ensure t :no-require t
   :config
   (global-set-key (kbd "M-x") 'smex)
@@ -978,7 +978,6 @@ The build string will be of the format:
 ;; #+STARTUP: indent hidestars inlineimages
 ;; #+TODO: TODO(t) ISSUE(i) EPIC(e) IDEA(i) BLOCK(b) SURVEY(s) PENDING(p) WIP(w) | DONE(d!) CANCEL(c!) DOC SPEC
 ;; #+COLUMNS: %40ITEM(Task) %17Effort(Estimated Effort){:} %CLOCKSUM
-;; (put 'narrow-to-region 'disabled nil)
 
 
 
@@ -1607,7 +1606,6 @@ The build string will be of the format:
  ("s-`" . our-async-exec-interactive)
  )
 
-
 ;; Record emacs startup time
 (setq initialize-end-time (float-time))
 (setq initialize-time-log-file-path "~/.emacs.d/starting-time.log")
@@ -1617,3 +1615,4 @@ The build string will be of the format:
 				     (- initialize-end-time initialize-start-time)
 				     initialize-time-log-file-path))
 (add-to-list 'auto-mode-alist '("\\.vue\\'" . html-mode))
+(put 'narrow-to-region 'disabled nil)

--- a/init.el
+++ b/init.el
@@ -358,7 +358,8 @@
 (use-package projectile :ensure t :defer t)
 (use-package org
   :config
-  (setq org-hide-leading-stars t
+  (setq org-archive-location "::* Archived Tasks"
+	org-hide-leading-stars t
 	org-startup-indented t
 	org-display-inline-images t
 	org-redisplay-inline-images t

--- a/init.el
+++ b/init.el
@@ -1621,3 +1621,23 @@ The build string will be of the format:
 
 ;; (el-get-bundle gist:0a849059d1fb61de397f57477ed38c92:trans :type "git")
 ;; (require 'trans)
+
+
+;; Graceful shutdown
+(setq
+ SIGKILL 9
+ SIGTERM 15)
+
+(defun process-graceful-shutdown-send-signal-running-process (proc signal)
+  "実行中のプロセスにシグナルを送信する。"
+  (when (eq (process-status proc) 'run)
+    (signal-process proc signal)))
+
+
+(defun process-graceful-shutdown (proc)
+  "Graceful shutdownする。"
+  (interactive (list
+                (completing-read "Process: " (mapcar #'process-name (process-list))
+                                 nil nil nil nil (tabulated-list-get-id))))
+  (process-graceful-shutdown-send-signal-running-process proc SIGTERM)
+  (run-at-time 30 nil #'process-graceful-shutdown-send-signal-running-process proc SIGKILL))

--- a/init.el
+++ b/init.el
@@ -243,6 +243,7 @@
 (el-get-bundle gist:beb8e1944af406c3fb4f74b6e0e3b5fe:require-to-install-executable :type "git")
 (el-get-bundle gist:c4c6ee198a1c576220a144ab825fa2f0:mastodon :type "git")
 (el-get-bundle gist:d451221dc2a280b7e35d:kpt.el :type "git")
+(el-get-bundle trans :type "git" :url "git@gist.github.com:0a849059d1fb61de397f57477ed38c92.git")
 (el-get-bundle gist:e8a10244aac6308de1323d1f6685658b:change-case :type "git")
 
 (require 'change-case)
@@ -253,9 +254,10 @@
 (require 'foreman-mode)
 (require 'go-template-mode)
 (require 'kpt)
+(require 'mastodon)
 (require 'org-file-table)
 (require 'require-to-install-executable)
-(require 'mastodon)
+(require 'trans)
 
 (with-current-buffer (find-file-noselect (expand-file-name "~/.config/mastodon/mstdn.jp"))
   (dotenv-mode-apply-all))

--- a/init.el
+++ b/init.el
@@ -243,7 +243,6 @@
 (el-get-bundle gist:beb8e1944af406c3fb4f74b6e0e3b5fe:require-to-install-executable :type "git")
 (el-get-bundle gist:c4c6ee198a1c576220a144ab825fa2f0:mastodon :type "git")
 (el-get-bundle gist:d451221dc2a280b7e35d:kpt.el :type "git")
-(el-get-bundle trans :type "git" :url "git@gist.github.com:0a849059d1fb61de397f57477ed38c92.git")
 (el-get-bundle gist:e8a10244aac6308de1323d1f6685658b:change-case :type "git")
 
 (require 'change-case)
@@ -257,7 +256,6 @@
 (require 'mastodon)
 (require 'org-file-table)
 (require 'require-to-install-executable)
-(require 'trans)
 
 (with-current-buffer (find-file-noselect (expand-file-name "~/.config/mastodon/mstdn.jp"))
   (dotenv-mode-apply-all))
@@ -370,6 +368,7 @@
          ("C-c C-c" . org-ctrl-c-ctrl-c)
 	 ("C-c C-e" . org-agenda-set-effort)
 	 ("C-c C-i" . org-agenda-clock-in)))
+(use-package org-agenda-property :ensure t)
 (use-package company :ensure t :pin melpa
   :config
   (global-company-mode)
@@ -954,9 +953,9 @@ The build string will be of the format:
 (custom-set-variables
  '(org-agenda-span 1)
  '(org-todo-keywords '((sequence
-			"INBOX" "MAYBE" "ACTION" "WAITING" "TODO" "EPIC"
+			"TODO(t)" "WIP(w)" "ISSUE(i)"
 			"|"
-			"DONE" "CANCEL")))
+			"CLOSE" "DONE" "FIX")))
  '(org-global-properties '(("Effort_ALL" . "1 2 3 5 8 13 21 34 55 89 144 233 377 610 987")))
  '(org-columns-default-format "%TODO %PRIORITY %Effort{:} %DEADLINE %ITEM %TAGS")
  '(org-agenda-columns-add-appointments-to-effort-sum t)
@@ -1618,3 +1617,6 @@ The build string will be of the format:
 				     initialize-time-log-file-path))
 (add-to-list 'auto-mode-alist '("\\.vue\\'" . html-mode))
 (put 'narrow-to-region 'disabled nil)
+
+;; (el-get-bundle gist:0a849059d1fb61de397f57477ed38c92:trans :type "git")
+;; (require 'trans)

--- a/init.el
+++ b/init.el
@@ -423,8 +423,11 @@
   (setq ido-vertical-define-keys 'C-n-and-C-p-only
 	ido-vertical-show-count t)
   )
-(use-package vterm :ensure t :defer t)
-
+(use-package vterm :ensure t :defer t
+  :bind (:map vterm-mode-map
+	      ("C-c C-v" . vterm-copy-mode)))
+(use-package rg :ensure t :defer t)
+(use-package ripgrep :ensure t :defer t)
 ;; (use-package wakatime-mode :ensure t :defer t
 ;;   :config
 ;;   (global-wakatime-mode))
@@ -1577,7 +1580,6 @@ The build string will be of the format:
            ("C-c C-c" . python-shell-send-buffer))
 (bind-keys :map editor-mode-map
 	   ("C-x C-s" . editor-save-as))
-
 ;; (bind-keys :map org-agenda-mode-map
 ;; 	   ("C-c C-c" . org-agenda-todo)
 ;; 	   ("C-c C-e" . org-agenda-set-effort)


### PR DESCRIPTION

# 修正内容


## 設定変更

-   yasnippetのスニペットを保存するディレクトリパスを/opt/ng/symdon/snippetsに設定した。
-   org-archiveのアーカイブファイルの生成を抑止した。
-   org-todoのキーワードをTODO, WIP, ISSUE, CLOSE, DONE, FIXに修正。


## 実装

-   process-graceful-shutdownを実装。


## パッケージのインストール

-   org-agenda-property
-   vterm


## キーバインド

-   "s-t"でorg-agenda-listを表示する。

